### PR TITLE
[hotfix] : 캘린더 공유 수락한 멤버의 캘린더 정보만 불러오기

### DIFF
--- a/functions/db/group.js
+++ b/functions/db/group.js
@@ -5,7 +5,7 @@ const findMember = async (client, userId) => {
   const { rows } = await client.query(
     `
     SELECT id as group_id, member_id, member_name FROM "send_group"
-    WHERE user_id = $1
+    WHERE user_id = $1 AND is_okay = true
     ORDER BY created_at
     
     `,

--- a/functions/db/schedule.js
+++ b/functions/db/schedule.js
@@ -51,7 +51,8 @@ const findCalendarByMemberId = async (client, memberId, startDate, endDate) => {
           , count(case when is_check=true THEN  1 END ) as is_check_count
     FROM schedule
     WHERE user_id = $1 AND schedule_date BETWEEN $2 AND $3
-    GROUP BY schedule_date;
+    GROUP BY schedule_date
+    ORDER BY schedule_date
 
   `,
     [memberId, startDate, endDate],


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->

🌱 작업한 브랜치

- hotfix/#58

🌱 작업한 내용

- 캘린더 공유를 수락한 멤버의 캘린더 정보만 조회되어야함

## 📮 관련 이슈

- Resolved: #58 
