### PR TITLE
Fix: 알림 리스트 전체 조회 시 sendGroupId값 추가

### DIFF
--- a/functions/db/group.js
+++ b/functions/db/group.js
@@ -79,7 +79,7 @@ const findCalendarInfo = async (client, userId) => {
   try {
     const { rows } = await client.query(
       `
-      SELECT notice_id, section, is_okay, is_send, n.created_at as created_at, username as sender_name
+      SELECT sg.id as sender_group_id, notice_id, section, is_okay, is_send, n.created_at as created_at, username as sender_name
       FROM notice as n JOIN send_group sg on n.id = sg.notice_id JOIN "user" u on u.id = n.sender_id
       WHERE n.user_id = $1
       `,

--- a/functions/db/notice.js
+++ b/functions/db/notice.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const convertSnakeToCamel = require('../lib/convertSnakeToCamel');
 
 // CREATE
-const addNotice = async (client, senderId, memberId, section) => {
+const addNotice = async (client, memberId, senderId, section) => {
   const { rows } = await client.query(
     `
     INSERT INTO notice

--- a/functions/service/noticeService.js
+++ b/functions/service/noticeService.js
@@ -30,7 +30,10 @@ const getNoticeList = async (userId) => {
 
     let infoList = [];
     calendarInfo.forEach((info) => infoList.push(info));
-    pillInfo.forEach((info) => infoList.push(info));
+    pillInfo.forEach((info) => {
+      info.senderGroupId = null;
+      infoList.push(info);
+    });
 
     infoList = infoList.sort((first, second) => first.createdAt - second.createdAt).reverse();
 


### PR DESCRIPTION
## 🌴 PR 요약

<!-- PR의 내용을 요약해주세요. -->
Fix: 알림 리스트 전체 조회 시 sendGroupId값 추가

🌱 작업한 브랜치

- feature/#175

🌱 작업한 내용

- 알림 리스트 전체 조회 시 sendGroupId값 추가

## 📮 관련 이슈

- Resolved: #175 
